### PR TITLE
Use chrome headless for tests

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -13,7 +13,14 @@ module.exports = {
       }
     },
     local: {
-      browsers: ["chrome"]
+      browsers: ["chrome"],
+      browserOptions: {
+        chrome: [
+          "headless",
+          "disable-gpu",
+          "no-sandbox"
+        ],
+      }
     }
   }
 };


### PR DESCRIPTION
This will fix the build error `org.openqa.selenium.WebDriverException: unknown error: DevToolsActivePort file doesn't exist`

https://travis-ci.org/gatanaso/time-field/builds/408383353 

